### PR TITLE
Create dark-themed developer portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,435 +1,93 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mohamed Abdelsamei | Senior Software Engineer</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <style>
-      :root {
-        /* Modern Light Theme */
-        --bg: #ffffff;
-        --text: #0f172a;
-        --accent: #2563eb;
-        --secondary: #e2e8f0;
-        --highlight: #1d4ed8;
-        --card-bg: #f8fafc;
-        --success: #16a34a;
-        --comment: #64748b;
-        --property: #0f766e;
-        --tag-bg: #f1f5f9;
-        --tag-text: #334155;
-        --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.1),
-          0 1px 2px rgba(0, 0, 0, 0.06);
-        --hover-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
-          0 4px 6px -4px rgba(0, 0, 0, 0.05);
-      }
-
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-        font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
-      }
-
-      html {
-        scroll-behavior: smooth;
-      }
-
-      ::selection {
-        background: var(--accent);
-        color: var(--bg);
-      }
-
-      body {
-        background: var(--bg);
-        color: var(--text);
-        line-height: 1.6;
-        padding: 2rem;
-      }
-
-      .container {
-        max-width: 800px;
-        margin: 0 auto;
-      }
-
-      .header {
-        display: flex;
-        align-items: flex-start;
-        gap: 2.5rem;
-        margin-bottom: 3rem;
-        position: relative;
-      }
-
-      .header-content {
-        flex: 1;
-      }
-
-      .prompt {
-        font-family: "Fira Code", monospace;
-        color: var(--accent);
-        margin-bottom: 1rem;
-        display: inline-block;
-        font-weight: 500;
-      }
-
-      .prompt::before {
-        content: "$ ";
-        color: var(--highlight);
-      }
-
-      .prompt::after {
-        content: "";
-        display: inline-block;
-        width: 8px;
-        height: 16px;
-        background: var(--accent);
-        animation: blink 1s step-end infinite;
-        margin-left: 4px;
-        vertical-align: middle;
-      }
-
-      @keyframes blink {
-        0%,
-        100% {
-          opacity: 1;
-        }
-        50% {
-          opacity: 0;
-        }
-      }
-
-      .name {
-        font-size: 2.5rem;
-        color: var(--text);
-        margin-bottom: 0.5rem;
-        font-weight: 700;
-        letter-spacing: -0.02em;
-      }
-
-      .bio {
-        color: var(--comment);
-        font-size: 1.2rem;
-        margin-bottom: 1rem;
-        font-weight: 500;
-      }
-
-      .about {
-        background: var(--card-bg);
-        padding: 1.75rem;
-        border-radius: 16px;
-        border: 1px solid var(--secondary);
-        margin: 2rem 0;
-        box-shadow: var(--card-shadow);
-      }
-
-      .about-content {
-        padding: 0.5rem 0;
-      }
-
-      .about-text {
-        color: var(--text);
-        font-size: 1.05rem;
-        line-height: 1.8;
-        position: relative;
-        padding-left: 1.25rem;
-        border-left: 2px solid var(--accent);
-      }
-
-      .links {
-        margin: 1.5rem 0;
-      }
-
-      .links a {
-        color: var(--accent);
-        text-decoration: none;
-        margin-right: 1.5rem;
-        transition: all 0.3s ease;
-        padding: 0.5rem 1rem;
-        border-radius: 8px;
-        border: 1px solid var(--secondary);
-        display: inline-block;
-        font-weight: 500;
-        font-size: 0.95rem;
-        background: var(--card-bg);
-      }
-
-      .links a:hover {
-        color: var(--highlight);
-        background: var(--secondary);
-        border-color: var(--accent);
-        transform: translateY(-2px);
-      }
-
-      .tech-section {
-        background: var(--card-bg);
-        padding: 1.75rem;
-        border-radius: 16px;
-        margin: 2rem 0;
-        border: 1px solid var(--secondary);
-        box-shadow: var(--card-shadow);
-      }
-
-      .section-title {
-        font-family: "Fira Code", monospace;
-        color: var(--comment);
-        font-size: 0.9rem;
-        margin-bottom: 1.25rem;
-        font-weight: 500;
-      }
-
-      .tech-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 1.5rem;
-      }
-
-      .tech-category {
-        margin-bottom: 1.5rem;
-      }
-
-      .category-name {
-        color: var(--property);
-        font-weight: 600;
-        margin-bottom: 0.75rem;
-        font-size: 0.875rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-      }
-
-      .tech-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.625rem;
-      }
-
-      .tech-tag {
-        background: var(--tag-bg);
-        color: var(--tag-text);
-        padding: 0.375rem 0.875rem;
-        border-radius: 8px;
-        font-size: 0.875rem;
-        border: 1px solid var(--secondary);
-        transition: all 0.3s ease;
-        font-weight: 500;
-      }
-
-      .tech-tag:hover {
-        background: var(--accent);
-        color: var(--bg);
-        border-color: var(--accent);
-        transform: translateY(-2px);
-      }
-
-      .status {
-        color: var(--success);
-        margin-top: 1rem;
-        font-size: 0.9rem;
-        font-weight: 500;
-      }
-
-      .status::before {
-        content: "● ";
-        color: var(--success);
-      }
-
-      .footer {
-        margin-top: 4rem;
-        padding: 2rem 0;
-        border-top: 1px solid var(--secondary);
-      }
-
-      .footer-content {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-
-      .footer-text {
-        color: var(--comment);
-        font-size: 0.9rem;
-      }
-
-      .footer-right {
-        display: flex;
-        gap: 1rem;
-      }
-
-      .footer-link {
-        color: var(--comment);
-        transition: all 0.3s ease;
-        padding: 0.5rem;
-        border-radius: 8px;
-        display: flex;
-        align-items: center;
-      }
-
-      .footer-link:hover {
-        color: var(--accent);
-        background: var(--secondary);
-        transform: translateY(-2px);
-      }
-
-      .footer-icon {
-        transition: transform 0.3s ease;
-      }
-
-      .footer-link:hover .footer-icon {
-        transform: scale(1.1);
-      }
-
-      @media (max-width: 768px) {
-        body {
-          padding: 1rem;
-        }
-
-        .name {
-          font-size: 2rem;
-        }
-
-        .links {
-          display: flex;
-          justify-content: center;
-          flex-wrap: wrap;
-          gap: 1rem;
-        }
-
-        .links a {
-          margin-right: 0;
-        }
-
-        .footer-content {
-          flex-direction: column;
-          gap: 1rem;
-          text-align: center;
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="header">
-        <div class="header-content">
-          <p class="prompt">whoami</p>
-          <h1 class="name">Mohamed Abdelsamei</h1>
-          <p class="bio">Senior Software Engineer</p>
-          <div class="links">
-            <a href="https://github.com/mohamed-abdelsamei" target="_blank"
-              >github</a
-            >
-            <a
-              href="https://www.linkedin.com/in/mohamed-abdelsamei/"
-              target="_blank"
-              >linkedin</a
-            >
-          </div>
-          <p class="status">Available for interesting projects</p>
-        </div>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mohamed Abdelsamei | Backend Engineer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="terminal">
+    <div class="terminal-bar">
+      <div class="prompt-wrapper">
+        <span class="prompt">mabdelsamei@home:~$</span><span class="cursor"></span>
       </div>
-
-      <div class="about">
-        <div class="section-title">// About Me</div>
-        <div class="about-content">
-          <p class="about-text">
-            Senior Software Engineer crafting cloud-native solutions and
-            distributed systems. Specialized in AWS serverless architecture and
-            modern JavaScript ecosystems. Building scalable applications with
-            Node.js, TypeScript, and Go. Passionate about clean code,
-            infrastructure as code, and developer experience.
-          </p>
-        </div>
-      </div>
-
-      <div class="tech-section">
-        <div class="section-title">// Technical Profile</div>
-        <div class="tech-grid">
-          <div class="tech-category">
-            <div class="category-name">Cloud & Infrastructure</div>
-            <div class="tech-tags">
-              <span class="tech-tag">AWS</span>
-              <span class="tech-tag">Serverless</span>
-              <span class="tech-tag">AWS CDK</span>
-              <span class="tech-tag">Terraform</span>
-            </div>
-          </div>
-
-          <div class="tech-category">
-            <div class="category-name">Backend</div>
-            <div class="tech-tags">
-              <span class="tech-tag">Node.js</span>
-              <span class="tech-tag">TypeScript</span>
-              <span class="tech-tag">JavaScript</span>
-              <span class="tech-tag">Go</span>
-            </div>
-          </div>
-
-          <div class="tech-category">
-            <div class="category-name">Frontend</div>
-            <div class="tech-tags">
-              <span class="tech-tag">React</span>
-              <span class="tech-tag">React Native</span>
-            </div>
-          </div>
-
-          <div class="tech-category">
-            <div class="category-name">Databases</div>
-            <div class="tech-tags">
-              <span class="tech-tag">NoSQL</span>
-              <span class="tech-tag">DynamoDB</span>
-              <span class="tech-tag">MongoDB</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <footer class="footer">
-        <div class="footer-content">
-          <div class="footer-left">
-            <p class="footer-text">© 2024 Mohamed Abdelsamei</p>
-          </div>
-          <div class="footer-right">
-            <a
-              href="https://github.com/mohamed-abdelsamei"
-              target="_blank"
-              class="footer-link"
-            >
-              <svg
-                height="20"
-                width="20"
-                viewBox="0 0 16 16"
-                class="footer-icon"
-              >
-                <path
-                  fill="currentColor"
-                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
-                ></path>
-              </svg>
-            </a>
-            <a
-              href="https://www.linkedin.com/in/mohamed-abdelsamei/"
-              target="_blank"
-              class="footer-link"
-            >
-              <svg
-                height="20"
-                width="20"
-                viewBox="0 0 24 24"
-                class="footer-icon"
-              >
-                <path
-                  fill="currentColor"
-                  d="M20.5 2h-17A1.5 1.5 0 002 3.5v17A1.5 1.5 0 003.5 22h17a1.5 1.5 0 001.5-1.5v-17A1.5 1.5 0 0020.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 118.3 6.5a1.78 1.78 0 01-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0013 14.19a.66.66 0 000 .14V19h-3v-9h2.9v1.3a3.11 3.11 0 012.7-1.4c1.55 0 3.36.86 3.36 3.66z"
-                ></path>
-              </svg>
-            </a>
-          </div>
-        </div>
-      </footer>
+      <nav class="nav">
+        <a href="#about">About</a>
+        <a href="#skills">Skills</a>
+        <a href="#projects">Projects</a>
+        <a href="#contact">Contact</a>
+      </nav>
+      <button id="theme-toggle" aria-label="Toggle theme"></button>
     </div>
-  </body>
+  </header>
+  <main>
+    <section id="hero" class="hero">
+      <h1>Building privacy-first backend systems with AWS &amp; SSI</h1>
+      <p>Backend engineer shaping digital trust with serverless architecture and decentralized identity.</p>
+      <div class="cta">
+        <a href="resume.pdf" class="btn">View Resume</a>
+        <a href="#contact" class="btn">Contact Me</a>
+        <a href="https://www.linkedin.com/in/mohamed-abdelsamei/" target="_blank" rel="noopener noreferrer" class="btn">LinkedIn</a>
+      </div>
+    </section>
+
+    <section id="about">
+      <h2>About</h2>
+      <p>
+        Backend engineer with 7+ years of experience building scalable cloud-native systems on AWS.
+        I specialize in serverless architecture, data privacy, and decentralized identity using
+        Verifiable Credentials and DIDs. Currently shaping digital trust at Affinidi with
+        OID4VP-based login systems.
+      </p>
+    </section>
+
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul class="skill-list">
+        <li><strong>Backend:</strong> Node.js, TypeScript, Rust, Dart</li>
+        <li><strong>Cloud:</strong> AWS, Lambda, DynamoDB, CDK, Terraform, Serverless</li>
+        <li><strong>Privacy &amp; Identity:</strong> SSI, Verifiable Credentials, OID4VP, DIDs</li>
+        <li><strong>Other:</strong> CI/CD, Docker, Microservices, Monorepos</li>
+      </ul>
+    </section>
+
+    <section id="projects">
+      <h2>Projects</h2>
+      <ul class="project-list">
+        <li><strong>Affinidi Login</strong> – Privacy-first login using OID4VP + VCs.</li>
+        <li><strong>Serverless Migration</strong> – Led transition from Kubernetes to AWS Lambda.</li>
+        <li><strong>Identity Verification Flow</strong> – Built user-centric verification using DIDs.</li>
+      </ul>
+    </section>
+
+    <section id="contact">
+      <h2>Contact</h2>
+      <p><a href="mailto:mabdelsamei@outlook.com">mabdelsamei@outlook.com</a></p>
+      <div class="social">
+        <a href="https://github.com/mohamed-abdelsamei" target="_blank" rel="noopener noreferrer">github</a>
+        <a href="https://www.linkedin.com/in/mohamed-abdelsamei/" target="_blank" rel="noopener noreferrer">linkedin</a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <p>© 2024 Mohamed Abdelsamei</p>
+  </footer>
+  <script>
+    const toggle = document.getElementById('theme-toggle');
+    const root = document.documentElement;
+    const stored = localStorage.getItem('theme') || 'dark';
+    root.dataset.theme = stored;
+    toggle.textContent = stored === 'dark' ? '☀️' : '🌙';
+    toggle.addEventListener('click', () => {
+      const next = root.dataset.theme === 'dark' ? 'light' : 'dark';
+      root.dataset.theme = next;
+      localStorage.setItem('theme', next);
+      toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+    });
+  </script>
+</body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,164 @@
+:root {
+  --bg: #0d1117;
+  --text: #e5e9f0;
+  --accent: #00ff9c;
+  --muted: #7d8590;
+}
+
+[data-theme="light"] {
+  --bg: #ffffff;
+  --text: #1a1a1a;
+  --accent: #0070f3;
+  --muted: #666666;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'JetBrains Mono', monospace;
+  line-height: 1.6;
+  font-size: 18px;
+}
+
+main {
+  display: grid;
+  gap: 4rem;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+section {
+  display: grid;
+  gap: 1rem;
+}
+
+header.terminal {
+  background: #000;
+  padding: 1rem 2rem;
+  font-size: 0.9rem;
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.terminal-bar nav {
+  margin-left: auto;
+  display: flex;
+  gap: 1rem;
+}
+
+.prompt-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.prompt {
+  color: var(--accent);
+}
+
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 4px;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+#theme-toggle {
+  background: none;
+  border: 1px solid var(--muted);
+  border-radius: 4px;
+  color: var(--text);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+#theme-toggle:hover {
+  border-color: var(--accent);
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+h1 {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1.25rem;
+  color: var(--muted);
+}
+
+.hero {
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.cta {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  color: var(--accent);
+}
+
+.btn:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+h2 {
+  color: var(--accent);
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.skill-list,
+.project-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+#contact .social {
+  display: flex;
+  gap: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem;
+  color: var(--muted);
+}
+


### PR DESCRIPTION
## Summary
- Add a navigation bar to the terminal-style header for quick access to site sections
- Remove placeholder blog section and tidy headings for a more professional layout
- Style header navigation and prompt wrapper for cleaner alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f0c17be4832da020bb5990c6ea5f