### PR TITLE
style: add focus outlines for anchors and buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,6 +101,12 @@ a:hover {
   text-decoration: underline;
 }
 
+a:focus,
+button:focus {
+  outline: 1px dashed var(--accent);
+  outline-offset: 2px;
+}
+
 footer {
   margin-top: 16px;
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- show visible focus for links and buttons using dashed accent outline
- ensure interactive elements remain keyboard navigable in DOM order

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f1f8ef4832d906b63604dd2af49