### PR TITLE
feat: add CLI summary with contact CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,16 +21,22 @@
 </head>
 <body>
 <div class="window">
-  <div class="bar">
-    <span class="dot red"></span>
-    <span class="dot yellow"></span>
-    <span class="dot green"></span>
-  </div>
-  <div id="output" aria-live="polite"></div>
-  <div class="input">
-    <span class="prompt">$</span>
-    <input id="cli" aria-label="Command line" autocomplete="off" autofocus />
-  </div>
+    <div class="bar">
+      <span class="dot red"></span>
+      <span class="dot yellow"></span>
+      <span class="dot green"></span>
+    </div>
+    <div class="cli-only">
+      <p><strong>Mohamed Abdelsamei</strong> — Senior Software Engineer</p>
+      <p>Cairo, Egypt</p>
+      <p class="credentials">AWS Certified Solutions Architect – Associate</p>
+      <p><a class="cta" href="mailto:mohamed@mabdelsamei.com">Email me</a></p>
+    </div>
+    <div id="output" aria-live="polite"></div>
+    <div class="input">
+      <span class="prompt">$</span>
+      <input id="cli" aria-label="Command line" autocomplete="off" autofocus />
+    </div>
 </div>
 <footer>© 2025 Mohamed Abdelsamei — <code>echo "Stay curious, stay private."</code></footer>
 <script>

--- a/style.css
+++ b/style.css
@@ -42,6 +42,12 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.cli-only {
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+}
+
 .dot {
   width: 12px;
   height: 12px;
@@ -105,6 +111,31 @@ a:focus,
 button:focus {
   outline: 1px dashed var(--accent);
   outline-offset: 2px;
+}
+
+.cta {
+  display: inline-block;
+  padding: 4px 8px;
+  margin-top: 8px;
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.cta:hover {
+  text-decoration: none;
+  opacity: 0.9;
+}
+
+.cta:focus {
+  outline: 1px dashed var(--cyan);
+  outline-offset: 2px;
+}
+
+.credentials {
+  font-size: 0.875rem;
+  color: var(--cyan);
 }
 
 footer {


### PR DESCRIPTION
## Summary
- add CLI-only summary with name, location, credentials, and email button
- style new `.cta` button and credentials strip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fef6420832d9330dff2ae6df173