### PR TITLE
feat: add Inter font and monospaced utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%2300c896'/%3E%3Ctext x='2' y='12' font-size='10' fill='%230b0f14'%3EMA%3C/text%3E%3C/svg%3E">
 <meta name="theme-color" content="#0b0f14">
@@ -34,8 +35,8 @@
     </div>
     <div id="output" aria-live="polite"></div>
     <div class="input">
-      <span class="prompt">$</span>
-      <input id="cli" aria-label="Command line" autocomplete="off" autofocus />
+      <span class="prompt mono">$</span>
+      <input id="cli" class="mono" aria-label="Command line" autocomplete="off" autofocus />
     </div>
 </div>
 <footer>© 2025 Mohamed Abdelsamei — <code>echo "Stay curious, stay private."</code></footer>
@@ -48,7 +49,7 @@ let historyIndex=0;
 function print(text){
   if(Array.isArray(text)){text.forEach(print);return;}
   const div=document.createElement('div');
-  div.className='line';
+  div.className='line mono';
   div.innerHTML=text;
   output.appendChild(div);
   output.scrollTop=output.scrollHeight;
@@ -70,8 +71,8 @@ const commands={
 
 function run(cmd){
   const line=document.createElement('div');
-  line.className='line';
-  line.innerHTML='<span class="prompt">$</span> '+cmd;
+  line.className='line mono';
+  line.innerHTML='<span class="prompt mono">$</span> '+cmd;
   output.appendChild(line);
   const action=commands[cmd];
   if(action){action();}

--- a/style.css
+++ b/style.css
@@ -19,11 +19,15 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'Inter', sans-serif;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+.mono {
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .window {
@@ -86,7 +90,7 @@ body {
   background: transparent;
   border: none;
   color: var(--text);
-  font: inherit;
+  font-size: inherit;
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- load Inter as the primary body font
- add `.mono` utility to keep JetBrains Mono for CLI prompt, input, and output lines

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a864610938832d9db49feae356df71