### PR TITLE
Use paragraphs for location and credentials

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
         <h1>Mohamed Abdelsamei</h1>
         <h2>Senior Software Engineer</h2>
         <!-- Location and certification -->
-        <h3 class="location">Berlin, Germany</h3>
-        <h3 class="credentials">AWS Certified Solutions Architect – Associate</h3>
+        <p class="location">Berlin, Germany</p>
+        <p class="credentials">AWS Certified Solutions Architect – Associate</p>
         <!-- Tagline conveying mission -->
         <p class="tagline mono">Building privacy‑first backend systems with serverless &amp; SSI</p>
         <h3>Skills</h3>

--- a/style.css
+++ b/style.css
@@ -76,7 +76,15 @@ body {
   color: var(--text);
 }
 
-.content h3.credentials {
+.content .location,
+.content .credentials {
+  margin: var(--space-sm) 0 0;
+  font-size: 1rem;
+  font-weight: normal;
+  color: var(--text);
+}
+
+.content .credentials {
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## Summary
- Replace `h3` tags for location and credentials with `p` elements in `index.html`
- Update CSS selectors to style new `location` and `credentials` paragraphs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9046d58d8832da70cf5c234713a5c