### PR TITLE
Refactor skills section markup and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,46 +45,48 @@
         <p class="credentials">AWS Certified Solutions Architect – Associate</p>
         <!-- Tagline conveying mission -->
         <p class="tagline mono">Building privacy‑first backend systems with serverless &amp; SSI</p>
-        <h3>Skills</h3>
-        <!-- Skills laid out by category -->
-        <div id="skillsGrid">
-          <div class="skill-category">
-            <strong>Backend</strong>
-            <ul>
-              <li>Node.js</li>
-              <li>TypeScript</li>
-              <li>Rust</li>
-              <li>Dart</li>
-            </ul>
+        <section id="skills">
+          <h2 id="skills-heading">Skills</h2>
+          <!-- Skills laid out by category -->
+          <div id="skillsGrid">
+            <div class="skill-category">
+              <strong>Backend</strong>
+              <ul>
+                <li>Node.js</li>
+                <li>TypeScript</li>
+                <li>Rust</li>
+                <li>Dart</li>
+              </ul>
+            </div>
+            <div class="skill-category">
+              <strong>Cloud &amp; Infrastructure</strong>
+              <ul>
+                <li>AWS (Lambda, API Gateway, DynamoDB)</li>
+                <li>Serverless</li>
+                <li>Terraform</li>
+                <li>AWS CDK</li>
+              </ul>
+            </div>
+            <div class="skill-category">
+              <strong>Identity &amp; Privacy</strong>
+              <ul>
+                <li>Self‑Sovereign Identity (SSI)</li>
+                <li>Verifiable Credentials (VCs)</li>
+                <li>OID4VP</li>
+                <li>DIDs</li>
+              </ul>
+            </div>
+            <div class="skill-category">
+              <strong>Tools</strong>
+              <ul>
+                <li>Docker</li>
+                <li>CI/CD</li>
+                <li>Git</li>
+                <li>Monorepos</li>
+              </ul>
+            </div>
           </div>
-          <div class="skill-category">
-            <strong>Cloud &amp; Infrastructure</strong>
-            <ul>
-              <li>AWS (Lambda, API Gateway, DynamoDB)</li>
-              <li>Serverless</li>
-              <li>Terraform</li>
-              <li>AWS CDK</li>
-            </ul>
-          </div>
-          <div class="skill-category">
-            <strong>Identity &amp; Privacy</strong>
-            <ul>
-              <li>Self‑Sovereign Identity (SSI)</li>
-              <li>Verifiable Credentials (VCs)</li>
-              <li>OID4VP</li>
-              <li>DIDs</li>
-            </ul>
-          </div>
-          <div class="skill-category">
-            <strong>Tools</strong>
-            <ul>
-              <li>Docker</li>
-              <li>CI/CD</li>
-              <li>Git</li>
-              <li>Monorepos</li>
-            </ul>
-          </div>
-        </div>
+        </section>
         <p>
           <a class="cta" href="mailto:mohamed@mabdelsamei.com">Email me</a>
         </p>

--- a/style.css
+++ b/style.css
@@ -69,13 +69,6 @@ body {
   margin: var(--space-sm) 0 0;
 }
 
-.content h3 {
-  margin: var(--space-sm) 0 0;
-  font-size: 1rem;
-  font-weight: normal;
-  color: var(--text);
-}
-
 .content .location,
 .content .credentials {
   margin: var(--space-sm) 0 0;
@@ -93,6 +86,17 @@ body {
   margin-bottom: var(--space-md);
   font-size: 0.9rem;
   color: var(--text-muted);
+}
+
+#skills {
+  margin-top: var(--space-md);
+}
+
+#skills h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: normal;
+  color: var(--text);
 }
 
 /* coloured dots in bar */


### PR DESCRIPTION
## Summary
- Wrap Skills heading and grid in semantic `<section id="skills">` with new `<h2 id="skills-heading">`
- Add styles for `#skills` and its `h2`, removing obsolete `.content h3` rule

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a908112754832d9806c1875f089ca5